### PR TITLE
run the app in CMD option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,7 @@ RUN apk add --update ncurses-libs && \
 
 COPY --from=build /build-src/_build/prod/rel/juntos /opt/app
 
+WORKDIR /opt/app
+
 EXPOSE 4000
-ENTRYPOINT ["/opt/app/bin/juntos", "start"]
+CMD ["bin/juntos", "start"]

--- a/lib/juntos_web/endpoint.ex
+++ b/lib/juntos_web/endpoint.ex
@@ -14,7 +14,8 @@ defmodule JuntosWeb.Endpoint do
     websocket: true,
     longpoll: false
 
-  socket "/live", Phoenix.LiveView.Socket, websocket: [timeout: 45_000, connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [timeout: 45_000, connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #


### PR DESCRIPTION
it allows us to get shell access to the container if it's needed